### PR TITLE
revert ice-pop version bump, update ice-box version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@addepar/ice-pop",
-  "version": "0.0.4",
+  "version": "0.0.3",
   "description": "The default blueprint for ember-cli addons.",
   "keywords": [
     "ember-addon"
@@ -18,7 +18,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "@addepar/ice-box": "^0.0.4",
+    "@addepar/ice-box": "^0.0.5",
     "@addepar/ice-popper": "^0.0.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@addepar/ice-box@^0.0.4":
-  version "0.0.4"
-  resolved "https://addepar.jfrog.io/addepar/api/npm/npm/@addepar/ice-box/-/@addepar/ice-box-0.0.4.tgz#1754610de441a24c4fc862adb0fee26b26f473f7"
+"@addepar/ice-box@^0.0.5":
+  version "0.0.5"
+  resolved "https://addepar.jfrog.io/addepar/api/npm/npm/@addepar/ice-box/-/@addepar/ice-box-0.0.5.tgz#868cd45be9c5d49b20f021e6254b0f195fb48282"
   dependencies:
     ember-cli-babel "^6.0.0"
 


### PR DESCRIPTION
When I merged my last pr I meant to remove the commit with the ice-pop version bump, instead I accidently removed the ice-box bump. This update addresses both. tldr; hurr durr thats what I get for not double checking