### PR TITLE
update popover and dropdown click target logic

### DIFF
--- a/addon/components/ice-popover.js
+++ b/addon/components/ice-popover.js
@@ -86,22 +86,23 @@ export default class IcePopover extends Component {
     this._clickHandler = () => {
       if (this.get('isOpen') === false) {
         this._insertPopover();
-      } else {
-        this._removePopover();
       }
     };
 
+    // Determines whether or not a body click should close the currently open popover
     this._handleBodyClick = (event) => {
-      // we want the body click to trigger on everything BUT the current target or popover,
-      // otherwise the click handler would get triggered twice when clicking the target,
-      // causing unforseen chaos down the line
-      if ((event.target !== this._target) && (!this._popperElement.contains(event.target))) {
+      // We do not want _removePopover to trigger when clicking inside of the popover.
+      // Here we check whether the body click event was also a popover container click event.
+      // We are comparing the click events because tracking the click element itself can
+      // be buggy if the content within the popover ever changes while its still open.
+      if (event !== this.eventClick) {
         this._removePopover();
       }
-      // Close the popover if click target has [data-popover-close] attribute,
-      // regardless of where it is in the dom.
-      // This could be problematic in the future if we ever have the use case for
-      // multiple popovers open. This would close all of them at the same time.
+      // We still want to allow purposeful closing of the popover from within,
+      // so this closes the popover if the click target has [data-popover-close]
+      // attribute, regardless of where it is in the dom.
+      // (This could be problematic in the future if we ever have the use case for
+      // multiple popovers open. This would close all of them at the same time.)
       if (event.target.attributes['data-popover-close']) {
         this._removePopover();
       }
@@ -135,6 +136,12 @@ export default class IcePopover extends Component {
       this._popperElement = document.getElementById(this._popperId);
 
       this._popperElement.addEventListener('transitionend', this._transitionEndHandler);
+
+      // We are storing the click event that happens directly on the popover container
+      // so that we can later compare it to the body click for closing logistics
+      this._popperElement.addEventListener('click', (event) => {
+        this.eventClick = event;
+      });
 
       document.body.addEventListener('click', this._handleBodyClick);
     };


### PR DESCRIPTION
While I was testing popover in Iverson for file attachments, I noticed that when deleting an item inside of the popover, the popover closed, as opposed to staying open as is intended. The reason is because I was detecting whether a popover item was clicked by seeing if the target element was contained by the popover. This broke here because since the item was deleted, it technically was no longer "contained" by the popover, and triggered the close anyway.
So @billy-addepar came up with the idea to track the click event from the popover directly, then compare it when the body click also gets triggered. Basically, when body click happens, its directly checking if the click was also a popover click, rather than taking a guess from where the element lives.

I made the same change to dropdown bc I forsee the same problem happening for ember selects (which will likely use dropdown)

@Addepar/ice 