### PR TITLE
refactor(decorators): Update to using ember-argument-decorators

### DIFF
--- a/addon/components/ice-popover.js
+++ b/addon/components/ice-popover.js
@@ -1,14 +1,13 @@
-import Ember from 'ember';
-import { property } from '@addepar/ice-box/utils/class';
 import { DEBUG } from '@glimmer/env';
 
-import layout from '../templates/components/ice-popover';
+import Component from '@ember/component';
+import { run } from '@ember/runloop';
+import { guidFor } from '@ember/object/internals';
 
-const {
-  run,
-  generateGuid,
-  Component
-} = Ember;
+import { argument, type, immutable } from 'ember-argument-decorators';
+import { unionOf } from 'ember-argument-decorators/types';
+
+import layout from '../templates/components/ice-popover';
 
 /**
  * Super simple popover component that uses popper.js. By default it targets its
@@ -53,7 +52,7 @@ const {
  * ```
  */
 export default class IcePopover extends Component {
-  @property layout = layout
+  layout = layout
 
   // ----- Public Settings ------
 
@@ -62,37 +61,53 @@ export default class IcePopover extends Component {
    * Can choose between auto, top, right, bottom, left
    * Can also add -start or -end modifier
    */
-  @property placement = 'right-start'
+  @argument
+  @type('string')
+  placement = 'right-start'
 
   /**
    * Selector or Element
    */
-  @property target = null
+  @immutable
+  @argument
+  @type(unionOf(null, 'string', Element))
+  target = null;
+
+  @argument
+  @type(unionOf(null, 'string'))
+  popoverTitle = null;
 
   // ----- Private Variables -----
 
   /**
    * Used to track if the tooltip is open and appended to the DOM
    */
-  @property isOpen = false
+  @type('boolean')
+  isOpen = false;
 
   /**
    * Used to track whether fade in/out animation should trigger
    */
-  @property isShowing = false
+  @type('boolean')
+  isShowing = false;
 
   /**
    * Used to store the popper element for adding/removing event listeners
    */
-  @property _popperElement = null
+  _popperElement = null;
 
   /**
    * Used to target/select the popper element after it's been inserted
    */
-  @property _popperId = ''
+  _popperId = `${guidFor(this)}_popper`;
 
-  init() {
-    super.init(...arguments);
+  /**
+   * Used to as a proxy to pass along the class of this component to the actual popper
+   */
+  _popperClass = '';
+
+  constructor() {
+    super();
 
     this._popperClass = this.class || '';
     this._popperClass += ` ${this.classNames.join(' ')}`;
@@ -102,8 +117,6 @@ export default class IcePopover extends Component {
         this._popperClass += ` ${binding.value()}`;
       }
     }
-
-    this._popperId = generateGuid();
   }
 
   didInsertElement() {

--- a/addon/components/ice-sub-dropdown.js
+++ b/addon/components/ice-sub-dropdown.js
@@ -1,11 +1,9 @@
-import Ember from 'ember';
-import { property } from '@addepar/ice-box/utils/class';
+import Component from '@ember/component';
+
+import { tagName } from 'ember-decorators/component';
+import { argument, type } from 'ember-argument-decorators';
 
 import layout from '../templates/components/ice-sub-dropdown';
-
-const {
-  Component
-} = Ember;
 
 /**
  * Subdropdown component that is used inside a dropdown menu item.
@@ -28,10 +26,9 @@ const {
  * {{/ice-dropdown}}
  * ```
  */
+@tagName('')
 export default class IceSubDropdown extends Component {
-  @property layout = layout
-
-  @property tagName =''
+  layout = layout
 
   // ----- Public Settings ------
 
@@ -40,5 +37,11 @@ export default class IceSubDropdown extends Component {
    * Should only use right-start, left-start, right-end, left-end.
    * Popper will auto move it if needed.
    */
-  @property placement = 'right-start'
+  @argument
+  @type('string')
+  placement = 'right-start'
+
+  @argument
+  @type('boolean')
+  renderInPlace = false;
 }

--- a/addon/components/ice-tooltip-icon.js
+++ b/addon/components/ice-tooltip-icon.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
-import { property } from '@addepar/ice-box/utils/class';
+import Component from '@ember/component';
+
+import { className, classNames, tagName } from 'ember-decorators/component';
+import { argument, type } from 'ember-argument-decorators';
 
 import layout from '../templates/components/ice-tooltip-icon';
-
-const { Component } = Ember;
 
 /**
  * A tooltip that has an icon as its target element,
@@ -23,33 +23,33 @@ const { Component } = Ember;
  * {{/ice-tooltip-icon}}
  * ```
  */
+@tagName('i')
+@classNames('fa', 'tooltip-icon')
 export default class IceTooltipIcon extends Component {
-  @property layout = layout
-
-  @property tagName ='i'
-
-  @property classNameBindings = [':fa', 'iconClass', ':tooltip-icon']
-
-  @property attributeBindings = ['testAttr:data-test-tooltip-icon']
-
-  @property testAttr = true
+  layout = layout
 
   // ----- Public Settings ------
 
   /**
    * The specific icon class that you want to use
    */
-  @property iconClass = 'fa-question-circle'
+  @className
+  @type('string')
+  iconClass = 'fa-question-circle';
 
   /**
    * Used to determine the placement of the tooltip;
    * Can choose between auto, top, right, bottom, left;
    * Can also add -start or -end modifier.
    */
-  @property placement = 'auto'
+  @argument
+  @type('string')
+  placement = 'auto';
 
   /**
    * An optional class to pass to the tooltip itself.
    */
-  @property tooltipClass = null
+  @argument
+  @type('string')
+  tooltipClass = '';
 }

--- a/addon/components/ice-tooltip.js
+++ b/addon/components/ice-tooltip.js
@@ -1,14 +1,13 @@
-import Ember from 'ember';
-import { property } from '@addepar/ice-box/utils/class';
 import { DEBUG } from '@glimmer/env';
 
-import layout from '../templates/components/ice-tooltip';
+import Component from '@ember/component';
+import { run } from '@ember/runloop';
+import { guidFor } from '@ember/object/internals';
 
-const {
-  run,
-  generateGuid,
-  Component
-} = Ember;
+import { argument, type, immutable } from 'ember-argument-decorators';
+import { unionOf } from 'ember-argument-decorators/types';
+
+import layout from '../templates/components/ice-tooltip';
 
 /**
  * Super simple tooltip component that uses popper.js. By default it targets its
@@ -46,7 +45,7 @@ const {
  * ```
  */
 export default class IceTooltip extends Component {
-  @property layout = layout
+  layout = layout
 
   // ----- Public Settings ------
 
@@ -55,37 +54,49 @@ export default class IceTooltip extends Component {
    * Can choose between auto, top, right, bottom, left;
    * Can also add -start or -end modifier
    */
-  @property placement = 'auto'
+  @argument
+  @type('string')
+  placement = 'auto';
 
   /**
    * Selector or Element
    */
-  @property target = null
+  @immutable
+  @argument
+  @type(unionOf(null, 'string', Element))
+  target = null;
 
   // ----- Private Variables -----
 
   /**
    * Used to track if the tooltip is open and appended to the DOM
    */
-  @property isOpen = false
+  @type('boolean')
+  isOpen = false;
 
   /**
    * Used to track whether fade in/out animation should trigger
    */
-  @property isShowing = false
+  @type('boolean')
+  isShowing = false;
 
   /**
    * Used to store the popper element for adding/removing event listeners
    */
-  @property _popperElement = null
+  _popperElement = null
 
   /**
    * Used to target/select the popper element after it's been inserted
    */
-  @property _popperId = ''
+  _popperId = `${guidFor(this)}_popper`;
 
-  init() {
-    super.init(...arguments);
+  /**
+   * Used to as a proxy to pass along the class of this component to the actual popper
+   */
+  _popperClass = '';
+
+  constructor() {
+    super();
 
     this._popperClass = this.class || '';
     this._popperClass += ` ${this.classNames.join(' ')}`;
@@ -95,8 +106,6 @@ export default class IceTooltip extends Component {
         this._popperClass += ` ${binding.value()}`;
       }
     }
-
-    this._popperId = generateGuid();
   }
 
   didInsertElement() {

--- a/addon/templates/components/ice-sub-dropdown.hbs
+++ b/addon/templates/components/ice-sub-dropdown.hbs
@@ -1,5 +1,5 @@
 {{#ice-dropdown
-  classNames="ice-sub-dropdown"
+  class="ice-sub-dropdown"
   placement=placement
   renderInPlace=renderInPlace
   isTriggeredOnHover=true

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -48,7 +48,7 @@ module.exports = {
         },
         resolutions: {
           'ember': 'lts-2-4',
-          'ember-cli-shims': null
+          'ember-cli-shims': '1.1.0'
         }
       },
       npm: {
@@ -66,7 +66,7 @@ module.exports = {
         },
         resolutions: {
           'ember': 'lts-2-8',
-          'ember-cli-shims': null
+          'ember-cli-shims': '1.1.0'
         }
       },
       npm: {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,8 +2,10 @@
 const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
-  var app = new EmberAddon(defaults, {
-    // Add options here
+  const app = new EmberAddon(defaults, {
+    'ember-test-selectors': {
+      disableParamTransform: true
+    }
   });
 
   /*

--- a/package.json
+++ b/package.json
@@ -18,10 +18,12 @@
   },
   "dependencies": {
     "@addepar/ice-box": "^0.1.0",
+    "ember-argument-decorators": "~0.6.1",
     "ember-cli-babel": "^6.3.0",
     "ember-cli-htmlbars": "^2.0.1",
-    "ember-decorators": "^1.2.2",
-    "ember-popper": "~0.5.0"
+    "ember-decorators": "^1.3.1",
+    "ember-legacy-class-transform": "~0.1.2",
+    "ember-popper": "~0.6.6"
   },
   "devDependencies": {
     "@addepar/eslint-config": "^1.0.0",
@@ -48,6 +50,7 @@
     "ember-native-dom-helpers": "^0.5.0",
     "ember-resolver": "^4.0.0",
     "ember-source": "~2.14.0",
+    "ember-test-selectors": "pzuraq/ember-test-selectors#24334cd9a0de17a4201c5354f8b4cd9ea774c208",
     "loader.js": "^4.2.3"
   },
   "engines": {

--- a/tests/helpers/components/tooltip-helpers.js
+++ b/tests/helpers/components/tooltip-helpers.js
@@ -1,7 +1,6 @@
 import { find, findAll, triggerEvent } from 'ember-native-dom-helpers';
 
 const TOOLTIP_SELECTOR = '[data-test-tooltip]';
-const TOOLTIP_ICON_SELECTOR = '[data-test-tooltip-icon]';
 
 /**
  * Get count of currently rendered tooltips in the DOM
@@ -11,25 +10,11 @@ const getTooltipsCount = () =>
   findAll(TOOLTIP_SELECTOR).length;
 
 /**
- * Get count of currently rendered tooltip icons in the DOM
- * @return {number}
- */
-const getTooltipIconsCount = () =>
-  findAll(TOOLTIP_ICON_SELECTOR).length;
-
-/**
  * Find currently rendered tooltip in the DOM
  * @return {object}
  */
 const getTooltip = () =>
   find(TOOLTIP_SELECTOR);
-
-/**
- * Find currently rendered tooltip icon in the DOM
- * @return {object}
- */
-const getTooltipIcon = () =>
-  find(TOOLTIP_ICON_SELECTOR);
 
 /**
  * Mimic mousing over the tooltip trigger point to open the tooltip box
@@ -47,11 +32,8 @@ const closeTooltip = (target) =>
 
 export {
   TOOLTIP_SELECTOR,
-  TOOLTIP_ICON_SELECTOR,
   getTooltipsCount,
-  getTooltipIconsCount,
   getTooltip,
-  getTooltipIcon,
   openTooltip,
   closeTooltip
 };

--- a/tests/integration/components/ice-tooltip-icon-test.js
+++ b/tests/integration/components/ice-tooltip-icon-test.js
@@ -4,6 +4,8 @@ import hbs from 'htmlbars-inline-precompile';
 import waitForAnimations from '../../helpers/wait-for-animations';
 import tooltipHelpers from '../../helpers/components/tooltip-helpers';
 
+import { find } from 'ember-native-dom-helpers';
+
 moduleForComponent('ice-tooltip-icon', 'Integration | Component | ice tooltip icon', {
   integration: true
 });
@@ -12,14 +14,15 @@ test('target icon renders', async function(assert) {
   assert.expect(2);
 
   this.render(hbs`
-    {{#ice-tooltip-icon}}
+    {{#ice-tooltip-icon data-test-tooltip-icon=true}}
       template block text
     {{/ice-tooltip-icon}}
   `);
 
-  assert.equal(tooltipHelpers.getTooltipIconsCount(), 1,
-    'a tooltip icon target is rendered');
-  assert.equal(tooltipHelpers.getTooltipIcon().classList.contains('fa-question-circle'), true,
+  const tooltip = find('[data-test-tooltip-icon]');
+
+  assert.ok(tooltip, 'a tooltip icon target is rendered');
+  assert.equal(tooltip.classList.contains('fa-question-circle'), true,
     'tooltip has correct default class');
 });
 
@@ -27,12 +30,12 @@ test('tooltip works as expected', async function(assert) {
   assert.expect(3);
 
   this.render(hbs`
-    {{#ice-tooltip-icon}}
+    {{#ice-tooltip-icon data-test-tooltip-icon=true}}
       template block text
     {{/ice-tooltip-icon}}
   `);
 
-  await tooltipHelpers.openTooltip(tooltipHelpers.TOOLTIP_ICON_SELECTOR);
+  await tooltipHelpers.openTooltip('[data-test-tooltip-icon]');
   await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
 
   assert.equal(tooltipHelpers.getTooltipsCount(), 1,
@@ -40,7 +43,7 @@ test('tooltip works as expected', async function(assert) {
   assert.equal(tooltipHelpers.getTooltip().textContent.trim(), 'template block text',
     'tooltip content renders');
 
-  await tooltipHelpers.closeTooltip(tooltipHelpers.TOOLTIP_ICON_SELECTOR);
+  await tooltipHelpers.closeTooltip('[data-test-tooltip-icon]');
   await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
 
   assert.equal(tooltipHelpers.getTooltipsCount(), 0,
@@ -51,14 +54,14 @@ test('tooltip icon class can be modified', async function(assert) {
   assert.expect(2);
 
   this.render(hbs`
-    {{#ice-tooltip-icon iconClass="fa-exclamation"}}
+    {{#ice-tooltip-icon data-test-tooltip-icon=true iconClass="fa-exclamation"}}
       template block text
     {{/ice-tooltip-icon}}
   `);
 
-  assert.equal(tooltipHelpers.getTooltipIcon().classList.contains('fa-exclamation'), true,
+  assert.equal(find('[data-test-tooltip-icon]').classList.contains('fa-exclamation'), true,
     'tooltip icon has new class');
-  assert.equal(tooltipHelpers.getTooltipIcon().classList.contains('fa-question-circle'), false,
+  assert.equal(find('[data-test-tooltip-icon]').classList.contains('fa-question-circle'), false,
     'tooltip icon no longer has default class');
 });
 
@@ -66,12 +69,12 @@ test('tooltip box modifier class can be added', async function(assert) {
   assert.expect(1);
 
   this.render(hbs`
-    {{#ice-tooltip-icon tooltipClass="error-tooltip"}}
+    {{#ice-tooltip-icon data-test-tooltip-icon=true tooltipClass="error-tooltip"}}
       template block text
     {{/ice-tooltip-icon}}
   `);
 
-  await tooltipHelpers.openTooltip(tooltipHelpers.TOOLTIP_ICON_SELECTOR);
+  await tooltipHelpers.openTooltip('[data-test-tooltip-icon]');
   await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
 
   assert.equal(tooltipHelpers.getTooltip().classList.contains('error-tooltip'), true,
@@ -82,12 +85,12 @@ test('tooltip box direction can be modified', async function(assert) {
   assert.expect(1);
 
   this.render(hbs`
-    {{#ice-tooltip-icon placement="bottom-end"}}
+    {{#ice-tooltip-icon data-test-tooltip-icon=true placement="bottom-end"}}
       template block text
     {{/ice-tooltip-icon}}
   `);
 
-  await tooltipHelpers.openTooltip(tooltipHelpers.TOOLTIP_ICON_SELECTOR);
+  await tooltipHelpers.openTooltip('[data-test-tooltip-icon]');
   await waitForAnimations(tooltipHelpers.TOOLTIP_SELECTOR);
 
   assert.equal(tooltipHelpers.getTooltip().getAttribute('x-placement'), 'bottom-end',

--- a/yarn.lock
+++ b/yarn.lock
@@ -66,9 +66,9 @@
   dependencies:
     "@glimmer/util" "^0.22.3"
 
-"@glimmer/resolver@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.3.1.tgz#41069345b6f41beb0948cc35d8e4aa60adcadfc5"
+"@glimmer/resolver@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/resolver/-/resolver-0.4.1.tgz#cd9644572c556e7e799de1cf8eff2b999cf5b878"
   dependencies:
     "@glimmer/di" "^0.2.0"
 
@@ -213,6 +213,12 @@ ansi-styles@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
   dependencies:
     color-convert "^1.0.0"
+
+ansi-styles@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
+  dependencies:
+    color-convert "^1.9.0"
 
 ansicolors@~0.2.1:
   version "0.2.1"
@@ -378,6 +384,14 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+babel-code-frame@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz#418a7b5f3f7dc9a4670e61b1158b4c5661bec98d"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.8.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -470,6 +484,15 @@ babel-eslint@^7.2.3:
     babel-types "^6.23.0"
     babylon "^6.17.0"
 
+babel-eslint@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.1.tgz#5d718be7a328625d006022eb293ed3008cbd6346"
+  dependencies:
+    babel-code-frame "7.0.0-beta.0"
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
+
 babel-generator@6.11.4:
   version "6.11.4"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.11.4.tgz#14f6933abb20c62666d27e3b7b9f5b9dc0712a9a"
@@ -528,6 +551,15 @@ babel-helper-explode-assignable-expression@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
+babel-helper-function-name@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz#d1b6779b647e5c5c31ebeb05e13b998e4d352d56"
+  dependencies:
+    babel-helper-get-function-arity "7.0.0-beta.0"
+    babel-template "7.0.0-beta.0"
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
@@ -537,6 +569,12 @@ babel-helper-function-name@^6.24.1:
     babel-template "^6.24.1"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
+
+babel-helper-get-function-arity@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz#9d1ab7213bb5efe1ef1638a8ea1489969b5a8b6e"
+  dependencies:
+    babel-types "7.0.0-beta.0"
 
 babel-helper-get-function-arity@^6.24.1:
   version "6.24.1"
@@ -595,6 +633,10 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
+babel-messages@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-7.0.0-beta.0.tgz#6df01296e49fc8fbd0637394326a167f36da817b"
+
 babel-messages@^6.23.0, babel-messages@^6.8.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -615,7 +657,7 @@ babel-plugin-dead-code-elimination@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz#5f7c451274dcd7cccdbfbb3e0b85dd28121f0f65"
 
-babel-plugin-debug-macros@^0.1.1, babel-plugin-debug-macros@^0.1.10:
+babel-plugin-debug-macros@^0.1.10:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.1.10.tgz#dd077ad6e1cc0a8f9bbc6405c561392ebfc9a01c"
   dependencies:
@@ -627,19 +669,32 @@ babel-plugin-debug-macros@^0.1.11:
   dependencies:
     semver "^5.3.0"
 
+babel-plugin-ember-legacy-class-constructor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-legacy-class-constructor/-/babel-plugin-ember-legacy-class-constructor-0.1.4.tgz#dfe715b9bdb66f6c7e9eccc620137c03b3fa89e0"
+
 babel-plugin-ember-modules-api-polyfill@^1.5.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-1.6.0.tgz#abd1afa4237b3121cb51222f9bf3283cad8990aa"
   dependencies:
     ember-rfc176-data "^0.2.0"
 
+babel-plugin-ember-modules-api-polyfill@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.1.0.tgz#78848cc4fcc2274882a6c15cbb23fefcdc771301"
+  dependencies:
+    ember-rfc176-data "^0.3.0"
+
 babel-plugin-eval@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz#a2faed25ce6be69ade4bfec263f70169195950da"
 
-babel-plugin-filter-imports@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-0.3.1.tgz#e7859b56886b175dd2616425d277b219e209ea8b"
+babel-plugin-filter-imports@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-filter-imports/-/babel-plugin-filter-imports-1.1.0.tgz#e5ea78f58f7fed4a22e59e136b52994c5fda7bad"
+  dependencies:
+    babel-types "^6.26.0"
+    lodash "^4.17.4"
 
 babel-plugin-htmlbars-inline-precompile@^0.2.3:
   version "0.2.3"
@@ -993,6 +1048,22 @@ babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtim
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
+babel-template@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-7.0.0-beta.0.tgz#85083cf9e4395d5e48bf5154d7a8d6991cafecfb"
+  dependencies:
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
+    lodash "^4.2.0"
+
 babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.3.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -1017,6 +1088,20 @@ babel-traverse@6.12.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-traverse@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz#da14be9b762f62a2f060db464eaafdd8cd072a41"
+  dependencies:
+    babel-code-frame "7.0.0-beta.0"
+    babel-helper-function-name "7.0.0-beta.0"
+    babel-messages "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
 babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
@@ -1031,6 +1116,14 @@ babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-types@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-7.0.0-beta.0.tgz#eb8b6e556470e6dcc4aef982d79ad229469b5169"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 babel-types@^6.10.2, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0, babel-types@^6.9.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
@@ -1040,6 +1133,15 @@ babel-types@^6.10.2, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
+babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
 babel6-plugin-strip-class-callcheck@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/babel6-plugin-strip-class-callcheck/-/babel6-plugin-strip-class-callcheck-6.0.0.tgz#de841c1abebbd39f78de0affb2c9a52ee228fddf"
@@ -1047,6 +1149,10 @@ babel6-plugin-strip-class-callcheck@^6.0.0:
 babylon@6.14.1:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
+
+babylon@7.0.0-beta.22:
+  version "7.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.22.tgz#74f0ad82ed7c7c3cfeab74cf684f815104161b65"
 
 babylon@^5.8.38:
   version "5.8.38"
@@ -1157,10 +1263,6 @@ bower-endpoint-parser@0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz#00b565adbfab6f2d35addde977e97962acbcb3f6"
 
-bower@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/bower/-/bower-1.8.0.tgz#55dbebef0ad9155382d9e9d3e497c1372345b44a"
-
 brace-expansion@^1.0.0, brace-expansion@^1.1.7:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.8.tgz#c07b211c7c952ec1f8efd51a77ef0d1d3990a292"
@@ -1181,13 +1283,13 @@ breakable@~1.0.0:
   resolved "https://registry.yarnpkg.com/breakable/-/breakable-1.0.0.tgz#784a797915a38ead27bad456b5572cb4bbaa78c1"
 
 broccoli-asset-rev@^2.4.5:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/broccoli-asset-rev/-/broccoli-asset-rev-2.5.0.tgz#f5f66eac962bf9f086286921f0eaeaab6d00d819"
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/broccoli-asset-rev/-/broccoli-asset-rev-2.6.0.tgz#0633fc3a0b2ba0c2c1d56fa9feb7b331fc83be6d"
   dependencies:
     broccoli-asset-rewrite "^1.1.0"
     broccoli-filter "^1.2.2"
     json-stable-stringify "^1.0.0"
-    matcher-collection "^1.0.1"
+    minimatch "^3.0.4"
     rsvp "^3.0.6"
 
 broccoli-asset-rewrite@^1.1.0:
@@ -1244,9 +1346,9 @@ broccoli-brocfile-loader@^0.18.0:
   dependencies:
     findup-sync "^0.4.2"
 
-broccoli-builder@^0.18.3:
-  version "0.18.5"
-  resolved "https://registry.yarnpkg.com/broccoli-builder/-/broccoli-builder-0.18.5.tgz#fb09687d99b869942e4405a2e4f4499272cfc5f2"
+broccoli-builder@^0.18.8:
+  version "0.18.8"
+  resolved "https://registry.yarnpkg.com/broccoli-builder/-/broccoli-builder-0.18.8.tgz#fe54694d544c3cdfdb01028e802eeca65749a879"
   dependencies:
     heimdalljs "^0.2.0"
     promise-map-series "^0.2.1"
@@ -1338,6 +1440,17 @@ broccoli-debug@^0.6.1, broccoli-debug@^0.6.2:
     esdoc "https://github.com/pzuraq/esdoc.git#bcd3f55bada45f0555f491cc3789c4dc3970d703"
     merge "~1.2.0"
 
+broccoli-file-creator@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-1.1.1.tgz#1b35b67d215abdfadd8d49eeb69493c39e6c3450"
+  dependencies:
+    broccoli-kitchen-sink-helpers "~0.2.0"
+    broccoli-plugin "^1.1.0"
+    broccoli-writer "~0.1.1"
+    mkdirp "^0.5.1"
+    rsvp "~3.0.6"
+    symlink-or-copy "^1.0.1"
+
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.2.4.tgz#409afb94b9a3a6da9fac8134e91e205f40cc7330"
@@ -1356,7 +1469,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.0.7, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1375,7 +1488,25 @@ broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.6, broccoli
     symlink-or-copy "^1.0.0"
     walk-sync "^0.3.1"
 
-broccoli-kitchen-sink-helpers@^0.2.5:
+broccoli-funnel@^2.0.0, broccoli-funnel@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.3.0"
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.5.3"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.3.1"
+
+broccoli-kitchen-sink-helpers@^0.2.5, broccoli-kitchen-sink-helpers@~0.2.0:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/broccoli-kitchen-sink-helpers/-/broccoli-kitchen-sink-helpers-0.2.9.tgz#a5e0986ed8d76fb5984b68c3f0450d3a96e36ecc"
   dependencies:
@@ -1401,7 +1532,7 @@ broccoli-lint-eslint@^3.3.0:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.2.1, broccoli-merge-trees@^1.2.4:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -1421,9 +1552,9 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
-broccoli-middleware@^1.0.0-beta.8:
-  version "1.0.0-beta.11"
-  resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.0.0-beta.11.tgz#5f633276c7905d2debf6fb78b18291f560fd4ba1"
+broccoli-middleware@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/broccoli-middleware/-/broccoli-middleware-1.0.0.tgz#92f4e1fb9a791ea986245a7077f35cc648dab097"
   dependencies:
     handlebars "^4.0.4"
     mime "^1.2.11"
@@ -1492,7 +1623,7 @@ broccoli-plugin@1.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.0.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.1.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.0.tgz#bee704a8e42da08cb58e513aaa436efb7f0ef1ee"
   dependencies:
@@ -1543,7 +1674,7 @@ broccoli-sri-hash@^2.1.0:
     sri-toolbox "^0.2.0"
     symlink-or-copy "^1.0.1"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.5.0:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.4.0, broccoli-stew@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
@@ -1575,6 +1706,13 @@ broccoli-uglify-sourcemap@^1.0.0:
     symlink-or-copy "^1.0.1"
     uglify-js "^2.7.0"
     walk-sync "^0.1.3"
+
+broccoli-writer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-writer/-/broccoli-writer-0.1.1.tgz#d4d71aa8f2afbc67a3866b91a2da79084b96ab2d"
+  dependencies:
+    quick-temp "^0.1.0"
+    rsvp "^3.0.6"
 
 browserslist@^2.1.2:
   version "2.1.5"
@@ -1697,6 +1835,14 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.0.tgz#b5ea48efc9c1793dccc9b4767c93914d3f2d52ba"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
 
 charm@^1.0.0:
   version "1.0.2"
@@ -1836,7 +1982,7 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-color-convert@^1.0.0:
+color-convert@^1.0.0, color-convert@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
   dependencies:
@@ -2117,6 +2263,12 @@ debug@2.6.8, debug@^2.1.0, debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.4.
   dependencies:
     ms "2.0.0"
 
+debug@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2285,6 +2437,17 @@ ember-ajax@^3.0.0:
   dependencies:
     ember-cli-babel "^6.0.0"
 
+ember-argument-decorators@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/ember-argument-decorators/-/ember-argument-decorators-0.6.1.tgz#c6170f999c63de0a6a31bd85b6587d850b4f404b"
+  dependencies:
+    babel-plugin-filter-imports "^1.1.0"
+    broccoli-funnel "^2.0.1"
+    ember-cli-babel "^6.3.0"
+    ember-cli-version-checker "^2.0.0"
+    ember-compatibility-helpers "^0.1.1"
+    ember-get-config "^0.2.3"
+
 ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-5.2.4.tgz#5ce4f46b08ed6f6d21e878619fb689719d6e8e13"
@@ -2295,7 +2458,7 @@ ember-cli-babel@^5.1.6, ember-cli-babel@^5.1.7:
     ember-cli-version-checker "^1.0.2"
     resolve "^1.1.2"
 
-ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.3.0:
+ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.4.1.tgz#785a1c24fe3250eb0776b1ab3cee857863b44542"
   dependencies:
@@ -2305,6 +2468,23 @@ ember-cli-babel@^6.0.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-be
     babel-polyfill "^6.16.0"
     babel-preset-env "^1.5.1"
     broccoli-babel-transpiler "^6.0.0"
+    broccoli-debug "^0.6.2"
+    broccoli-funnel "^1.0.0"
+    broccoli-source "^1.1.0"
+    clone "^2.0.0"
+    ember-cli-version-checker "^2.0.0"
+
+ember-cli-babel@^6.3.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+  version "6.8.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
+  dependencies:
+    amd-name-resolver "0.0.7"
+    babel-plugin-debug-macros "^0.1.11"
+    babel-plugin-ember-modules-api-polyfill "^2.0.1"
+    babel-plugin-transform-es2015-modules-amd "^6.24.0"
+    babel-polyfill "^6.16.0"
+    babel-preset-env "^1.5.1"
+    broccoli-babel-transpiler "^6.1.2"
     broccoli-debug "^0.6.2"
     broccoli-funnel "^1.0.0"
     broccoli-source "^1.1.0"
@@ -2380,17 +2560,17 @@ ember-cli-get-dependency-depth@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-get-dependency-depth/-/ember-cli-get-dependency-depth-1.0.0.tgz#e0afecf82a2d52f00f28ab468295281aec368d11"
 
 ember-cli-htmlbars-inline-precompile@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.4.3.tgz#4123f507fea6c59ba4c272ef7e713a6d55ba06c9"
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-0.4.4.tgz#24a7617152630d64a047e553b72e00963a4f8d73"
   dependencies:
     babel-plugin-htmlbars-inline-precompile "^0.2.3"
     ember-cli-version-checker "^2.0.0"
     hash-for-dep "^1.0.2"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@^2.0.0, ember-cli-htmlbars@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.2.tgz#230a9ace7c3454b3acff2768a50f963813a90c38"
+ember-cli-htmlbars@^2.0.1, ember-cli-htmlbars@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.3.tgz#e116e1500dba12f29c94b05b9ec90f52cb8bb042"
   dependencies:
     broccoli-persistent-filter "^1.0.3"
     hash-for-dep "^1.0.2"
@@ -2398,8 +2578,8 @@ ember-cli-htmlbars@^2.0.0, ember-cli-htmlbars@^2.0.1:
     strip-bom "^3.0.0"
 
 ember-cli-inject-live-reload@^1.4.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.6.1.tgz#82b8f5be454815a75e7f6d42c9ce0bc883a914a3"
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-inject-live-reload/-/ember-cli-inject-live-reload-1.7.0.tgz#af94336e015336127dfb98080ad442bb233e37ed"
 
 ember-cli-is-package-missing@^1.0.0:
   version "1.0.0"
@@ -2466,27 +2646,28 @@ ember-cli-preprocess-registry@^3.1.0:
     silent-error "^1.0.0"
 
 ember-cli-qunit@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-qunit/-/ember-cli-qunit-4.0.0.tgz#1f0022469a5bd64f627b8102880a25e94e533a3b"
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-qunit/-/ember-cli-qunit-4.0.1.tgz#905aa07620ae9fdb417c7e48d45bd2277b62f864"
   dependencies:
-    broccoli-funnel "^1.0.1"
+    broccoli-funnel "^2.0.0"
     broccoli-merge-trees "^2.0.0"
-    ember-cli-babel "^6.0.0-beta.7"
-    ember-cli-test-loader "^2.0.0"
-    ember-cli-version-checker "^1.1.4"
-    ember-qunit "^2.1.3"
+    ember-cli-babel "^6.8.1"
+    ember-cli-test-loader "^2.2.0"
+    ember-cli-version-checker "^2.0.0"
+    ember-qunit "^2.2.0"
     qunit-notifications "^0.1.1"
-    qunitjs "^2.0.1"
-    resolve "^1.1.6"
-    silent-error "^1.0.0"
+    qunitjs "^2.4.0"
+    resolve "^1.4.0"
+    silent-error "^1.1.0"
 
 ember-cli-sass-lint@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/ember-cli-sass-lint/-/ember-cli-sass-lint-1.0.4.tgz#5c2097315efa0799670aedf569152b5d88a0c251"
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/ember-cli-sass-lint/-/ember-cli-sass-lint-1.0.5.tgz#f8e914721ca4ad2341a7fb684423663d4209f33b"
   dependencies:
-    broccoli-merge-trees "^1.2.1"
+    broccoli-funnel "^1.2.0"
+    broccoli-merge-trees "^2.0.0"
     broccoli-sass-lint "^1.1.2"
-    ember-cli-babel "^5.1.7"
+    ember-cli-babel "^6.6.0"
 
 ember-cli-sass@^6.1.3:
   version "6.2.0"
@@ -2522,11 +2703,11 @@ ember-cli-test-info@^1.0.0:
   dependencies:
     ember-cli-string-utils "^1.0.0"
 
-ember-cli-test-loader@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-test-loader/-/ember-cli-test-loader-2.1.0.tgz#16163bae0ac32cad1af13c4ed94c6c698b54d431"
+ember-cli-test-loader@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz#3fb8d5d1357e4460d3f0a092f5375e71b6f7c243"
   dependencies:
-    ember-cli-babel "^6.0.0-beta.7"
+    ember-cli-babel "^6.8.1"
 
 ember-cli-uglify@^1.2.0:
   version "1.2.0"
@@ -2540,7 +2721,7 @@ ember-cli-valid-component-name@^1.0.0:
   dependencies:
     silent-error "^1.0.0"
 
-ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.4, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0, ember-cli-version-checker@^1.3.1:
+ember-cli-version-checker@^1.0.2, ember-cli-version-checker@^1.1.6, ember-cli-version-checker@^1.1.7, ember-cli-version-checker@^1.2.0, ember-cli-version-checker@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-1.3.1.tgz#0bc2d134c830142da64bf9627a0eded10b61ae72"
   dependencies:
@@ -2553,9 +2734,16 @@ ember-cli-version-checker@^2.0.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz#fc79a56032f3717cf844ada7cbdec1a06fedb604"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@~2.14.0:
-  version "2.14.0"
-  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.14.0.tgz#9aff1414168883183e8677fa32626d1e3228ccbc"
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.14.2.tgz#f2c8c75d486ce6cc6b7ffbc22ebef8b32bb242b7"
   dependencies:
     amd-name-resolver "0.0.6"
     babel-plugin-transform-es2015-modules-amd "^6.24.0"
@@ -2563,14 +2751,14 @@ ember-cli@~2.14.0:
     bower-endpoint-parser "0.2.2"
     broccoli-babel-transpiler "^6.0.0"
     broccoli-brocfile-loader "^0.18.0"
-    broccoli-builder "^0.18.3"
+    broccoli-builder "^0.18.8"
     broccoli-concat "^3.2.2"
     broccoli-config-loader "^1.0.0"
     broccoli-config-replace "^1.1.2"
     broccoli-funnel "^1.0.6"
     broccoli-funnel-reducer "^1.0.0"
     broccoli-merge-trees "^2.0.0"
-    broccoli-middleware "^1.0.0-beta.8"
+    broccoli-middleware "^1.0.0"
     broccoli-source "^1.1.0"
     broccoli-stew "^1.2.0"
     calculate-cache-key-for-tree "^1.0.0"
@@ -2651,19 +2839,17 @@ ember-compatibility-helpers@^0.1.0:
     ember-cli-version-checker "^2.0.0"
     semver "^5.4.1"
 
-ember-decorators@^1.2.0:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-1.2.1.tgz#dce9b9f1ae3999ea0fadf205370b8600238954d6"
+ember-compatibility-helpers@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-0.1.1.tgz#70a26c0d28715bbb23eb1be343d7203e492afa68"
   dependencies:
-    babel-plugin-transform-class-properties "^6.24.1"
-    babel-plugin-transform-decorators-legacy "^1.3.4"
-    ember-cli-babel "^6.0.0"
+    babel-plugin-debug-macros "^0.1.11"
     ember-cli-version-checker "^2.0.0"
-    ember-macro-helpers "^0.15.1"
+    semver "^5.4.1"
 
-ember-decorators@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-1.2.2.tgz#ba95769b6da0c9f86ddf74ea3fe733d260845f00"
+ember-decorators@^1.3.0, ember-decorators@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/ember-decorators/-/ember-decorators-1.3.1.tgz#00027da711c200bdeaf9e572ea3d96957e13013d"
   dependencies:
     babel-plugin-transform-class-properties "^6.24.1"
     babel-plugin-transform-decorators-legacy "^1.3.4"
@@ -2673,16 +2859,21 @@ ember-decorators@^1.2.2:
     ember-macro-helpers "^0.16.0"
 
 ember-disable-prototype-extensions@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.2.tgz#261cccaf6bf8fbb1836be7bdfe4278f9ab92b873"
-  dependencies:
-    bower "^1.8.0"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"
 
 ember-export-application-global@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ember-export-application-global/-/ember-export-application-global-2.0.0.tgz#8d6d7619ac8a1a3f8c43003549eb21ebed685bd2"
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
+
+ember-get-config@^0.2.3:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
+  dependencies:
+    broccoli-file-creator "^1.1.1"
+    ember-cli-babel "^6.3.0"
 
 ember-hash-helper-polyfill@^0.1.2:
   version "0.1.2"
@@ -2691,20 +2882,19 @@ ember-hash-helper-polyfill@^0.1.2:
     ember-cli-babel "^5.1.7"
     ember-cli-version-checker "^1.2.0"
 
+ember-legacy-class-transform@~0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ember-legacy-class-transform/-/ember-legacy-class-transform-0.1.2.tgz#f09e1b002ac4141096051a4ce387ba6828eddb16"
+  dependencies:
+    babel-plugin-ember-legacy-class-constructor "^0.1.4"
+    ember-cli-babel "^6.3.0"
+    ember-cli-version-checker "^2.0.0"
+
 ember-load-initializers@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
-
-ember-macro-helpers@^0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/ember-macro-helpers/-/ember-macro-helpers-0.15.1.tgz#a402651fafb3a25b3612a8c09843bc4061553a13"
-  dependencies:
-    ember-cli-babel "^6.0.0"
-    ember-cli-string-utils "^1.1.0"
-    ember-cli-test-info "^1.0.0"
-    ember-weakmap "^2.0.0"
 
 ember-macro-helpers@^0.16.0:
   version "0.16.0"
@@ -2725,49 +2915,52 @@ ember-maybe-import-regenerator@^0.1.6:
     regenerator-runtime "^0.9.5"
 
 ember-native-dom-helpers@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.0.tgz#a3a12215cfdfa518472e203fdc15b485cea23670"
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/ember-native-dom-helpers/-/ember-native-dom-helpers-0.5.4.tgz#0bc1506a643fb7adc0abf1d09c44a7914459296b"
   dependencies:
     broccoli-funnel "^1.1.0"
-    ember-cli-babel "^6.1.0"
+    ember-cli-babel "^6.6.0"
 
-ember-popper@~0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.5.0.tgz#142b0df590660c21b25427d4f8cf121b87064b82"
+ember-popper@~0.6.6:
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/ember-popper/-/ember-popper-0.6.6.tgz#857c521fae024eab06ccafe0bad3f02ecf1aa4a6"
   dependencies:
-    babel-eslint "^7.2.3"
-    babel-plugin-filter-imports "^0.3.1"
+    babel-eslint "^8.0.1"
     babel6-plugin-strip-class-callcheck "^6.0.0"
-    broccoli-funnel "^1.0.7"
-    ember-cli-babel "^6.3.0"
-    ember-cli-htmlbars "^2.0.0"
+    broccoli-funnel "^2.0.0"
+    ember-cli-babel "^6.8.2"
+    ember-cli-htmlbars "^2.0.3"
     ember-cli-node-assets "^0.2.2"
-    ember-cli-version-checker "^2.0.0"
-    ember-decorators "^1.2.0"
+    ember-cli-version-checker "^2.1.0"
+    ember-decorators "^1.3.0"
     fastboot-transform "^0.1.0"
-    popper.js "^1.10.8"
+    popper.js "^1.12.5"
 
-ember-qunit@^2.1.3:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-2.1.4.tgz#5732794e668f753d8fe1a353692ffeda73742d29"
+ember-qunit@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ember-qunit/-/ember-qunit-2.2.0.tgz#3cdf400031c93a38de781a7304819738753b7f99"
   dependencies:
     ember-test-helpers "^0.6.3"
 
 ember-resolver@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ember-resolver/-/ember-resolver-4.1.0.tgz#f02aeb2f1f2e944ed47e085412a7b84f759d11df"
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/ember-resolver/-/ember-resolver-4.5.0.tgz#9248bf534dfc197fafe3118fff538d436078bf99"
   dependencies:
-    "@glimmer/resolver" "^0.3.0"
-    babel-plugin-debug-macros "^0.1.1"
+    "@glimmer/resolver" "^0.4.1"
+    babel-plugin-debug-macros "^0.1.10"
     broccoli-funnel "^1.1.0"
     broccoli-merge-trees "^2.0.0"
-    ember-cli-babel "^6.0.0-beta.7"
-    ember-cli-version-checker "^1.1.6"
-    resolve "^1.3.2"
+    ember-cli-babel "^6.8.1"
+    ember-cli-version-checker "^2.0.0"
+    resolve "^1.3.3"
 
 ember-rfc176-data@^0.2.0:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.2.7.tgz#bd355bc9b473e08096b518784170a23388bc973b"
+
+ember-rfc176-data@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-rfc176-data/-/ember-rfc176-data-0.3.0.tgz#6aee728cb521c5f80710990965027b9c320f6f08"
 
 ember-router-generator@^1.0.0:
   version "1.2.3"
@@ -2803,6 +2996,14 @@ ember-source@~2.14.0:
 ember-test-helpers@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/ember-test-helpers/-/ember-test-helpers-0.6.3.tgz#f864cdf6f4e75f3f8768d6537785b5ab6e82d907"
+
+ember-test-selectors@pzuraq/ember-test-selectors#24334cd9a0de17a4201c5354f8b4cd9ea774c208:
+  version "0.3.7"
+  resolved "https://codeload.github.com/pzuraq/ember-test-selectors/tar.gz/24334cd9a0de17a4201c5354f8b4cd9ea774c208"
+  dependencies:
+    broccoli-stew "^1.4.0"
+    ember-cli-babel "^6.8.2"
+    ember-cli-version-checker "^2.0.0"
 
 ember-try-config@^2.0.1:
   version "2.1.0"
@@ -3771,6 +3972,10 @@ global-prefix@^0.1.4:
     is-windows "^0.2.0"
     which "^1.2.12"
 
+globals@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.1.0.tgz#4425a1881be0d336b4a823a82a7be725d5dd987c"
+
 globals@^6.4.0:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/globals/-/globals-6.4.1.tgz#8498032b3b6d1cc81eebc5f79690d8fe29fabf4f"
@@ -3868,6 +4073,10 @@ has-binary@0.1.7:
 has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
+
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -4507,8 +4716,8 @@ load-json-file@^2.0.0:
     strip-bom "^3.0.0"
 
 loader.js@^4.2.3:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.5.0.tgz#fa4369702f176410c810605999f79dd590ff3308"
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.6.0.tgz#b965663ddbe2d80da482454cb865efe496e93e22"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -4709,7 +4918,7 @@ lodash@^3.10.0, lodash@^3.10.1, lodash@^3.9.3:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.6.1, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4777,7 +4986,7 @@ marked@0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
-matcher-collection@^1.0.0, matcher-collection@^1.0.1:
+matcher-collection@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.0.4.tgz#2f66ae0869996f29e43d0b62c83dd1d43e581755"
   dependencies:
@@ -4887,7 +5096,7 @@ mime@^1.2.11:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.2:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -5368,9 +5577,9 @@ pluralize@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
 
-popper.js@^1.10.8:
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.10.8.tgz#0fd6343e68aa8c1cc8cfe35e02c673500a1bc609"
+popper.js@^1.12.5:
+  version "1.12.6"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.12.6.tgz#91e12a97b07815258b76915d64044e8ac053d426"
 
 portfinder@^1.0.7:
   version "1.0.13"
@@ -5439,7 +5648,7 @@ qs@6.4.0, qs@^6.4.0, qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
-quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
+quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/quick-temp/-/quick-temp-0.1.8.tgz#bab02a242ab8fb0dd758a3c9776b32f9a5d94408"
   dependencies:
@@ -5451,9 +5660,9 @@ qunit-notifications@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/qunit-notifications/-/qunit-notifications-0.1.1.tgz#3001afc6a6a77dfbd962ccbcddde12dec5286c09"
 
-qunitjs@^2.0.1:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.3.3.tgz#456696bdd61a2c8b5bc8f053f00e20d75a73d539"
+qunitjs@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/qunitjs/-/qunitjs-2.4.1.tgz#88aba055a9e2ec3dbebfaad02471b2cb002c530b"
   dependencies:
     chokidar "1.6.1"
     commander "2.9.0"
@@ -5612,6 +5821,10 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
 regenerator-runtime@^0.9.5:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
@@ -5761,9 +5974,15 @@ resolve@1.3.2:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.0, resolve@^1.3.2, resolve@^1.3.3:
+resolve@^1.1.2, resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.0, resolve@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@^1.4.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.5.0.tgz#1f09acce796c9a762579f31b2c1cc4c3cddf9f36"
   dependencies:
     path-parse "^1.0.5"
 
@@ -5793,6 +6012,10 @@ rimraf@~2.2.6:
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.5.0.tgz#a62c573a4ae4e1dfd0697ebc6242e79c681eaa34"
+
+rsvp@~3.0.6:
+  version "3.0.21"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.0.21.tgz#49c588fe18ef293bcd0ab9f4e6756e6ac433359f"
 
 rsvp@~3.2.1:
   version "3.2.1"
@@ -6257,6 +6480,12 @@ supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
 
+supports-color@^4.0.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
+  dependencies:
+    has-flag "^2.0.0"
+
 "symbol-tree@>= 3.1.0 < 4.0.0":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
@@ -6391,9 +6620,13 @@ to-array@0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/to-array/-/to-array-0.1.4.tgz#17e6c11f73dd4f3d74cda7a4ff3238e9ad9bf890"
 
-to-fast-properties@^1.0.0, to-fast-properties@^1.0.1:
+to-fast-properties@^1.0.0, to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 tough-cookie@^2.2.0, tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
Updates the ES class syntax we are using to use the latest ember-decorators and ember-argument-decorators. This PR focusses on updating style and does minimal changes otherwise, I'll be following up with another PR that simplifies the components themselves, and refactors tests to use ember-cli-page-object
