### PR TITLE
[bugfix] Pass arguments in constructor

### DIFF
--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -136,7 +136,7 @@ export default class BasePopMenuComponent extends Component {
   }
 
   constructor() {
-    super();
+    super(...arguments);
 
     this._popperClass = `adde-base-pop-menu ${this.class || ''} ${this.classNames.join(' ')}`;
 


### PR DESCRIPTION
A recent change in Ember init arguments actually be passed into the
constructor, so we have to make sure we forward them for everything
to keep working as expected