### PR TITLE
Check for isdestroyed before setting state when we're closing a popper

### DIFF
--- a/addon/components/-private/animated-popper.js
+++ b/addon/components/-private/animated-popper.js
@@ -189,11 +189,10 @@ export default class AnimatedPopperComponent extends Component {
    * and notifies the parent context that animations have finished.
    */
   finalizeClose() {
+    if (this.isDestroyed) {
+      return;
+    }
     run(() => {
-      if (this.get('isDestroyed')) {
-        return;
-      }
-
       this.set('renderInDOM', false);
 
       if (this._hasTransition) {

--- a/addon/components/-private/animated-popper.js
+++ b/addon/components/-private/animated-popper.js
@@ -190,6 +190,10 @@ export default class AnimatedPopperComponent extends Component {
    */
   finalizeClose() {
     run(() => {
+      if (this.get('isDestroyed')) {
+        return;
+      }
+
       this.set('renderInDOM', false);
 
       if (this._hasTransition) {

--- a/tests/integration/components/adde-popover-test.js
+++ b/tests/integration/components/adde-popover-test.js
@@ -315,34 +315,6 @@ test('First item autofocuses when opened by keyboard only', async function(asser
   assert.ok(!popover.content.buttonWithFocus.isPresent, 'first button does not have focus');
 });
 
-test('popover box can teardown successfully during animation', async function(assert) {
-  assert.expect(2);
-
-  this.set('isShowing', true);
-  this.render(hbs`
-    {{#if isShowing}}
-      <div>
-        Target
-        {{#adde-popover data-test-popover=true}}
-          template block text
-        {{/adde-popover}}
-      </div>
-    {{/if}}
-  `);
-
-  let popover = new PopoverHelper();
-
-  await popover.open();
-
-  assert.ok(popover.isOpen, 'popover is rendered');
-
-  popover.close();
-
-  this.set('isShowing', false);
-
-  assert.ok(true, 'popover teardown can occur during close animation');
-});
-
 moduleForComponent('adde-popover', 'Unit | Component | adde-popover', {
   unit: true
 });

--- a/tests/integration/components/adde-popover-test.js
+++ b/tests/integration/components/adde-popover-test.js
@@ -315,6 +315,34 @@ test('First item autofocuses when opened by keyboard only', async function(asser
   assert.ok(!popover.content.buttonWithFocus.isPresent, 'first button does not have focus');
 });
 
+test('popover box can teardown successfully during animation', async function(assert) {
+  assert.expect(2);
+
+  this.set('isShowing', true);
+  this.render(hbs`
+    {{#if isShowing}}
+      <div>
+        Target
+        {{#adde-popover data-test-popover=true}}
+          template block text
+        {{/adde-popover}}
+      </div>
+    {{/if}}
+  `);
+
+  let popover = new PopoverHelper();
+
+  await popover.open();
+
+  assert.ok(popover.isOpen, 'popover is rendered');
+
+  popover.close();
+
+  this.set('isShowing', false);
+
+  assert.ok(true, 'popover teardown can occur during close animation');
+});
+
 moduleForComponent('adde-popover', 'Unit | Component | adde-popover', {
   unit: true
 });


### PR DESCRIPTION
I have an issue where when I make the call to close the panel and then 
transition away shortly after, the transition happens in the middle of the close
and when it gets to line 193 it errors out because the component has already
been destroyed. This should fix that issue, not sure how I might test this
or what the testing framework looks like in this repo. 