### PR TITLE
[FEATURE] The dropdown sends `willDestroyCallback` action when destroyed

### DIFF
--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -107,6 +107,14 @@ export default class BasePopMenuComponent extends Component {
   didInsertCallback = null;
 
   /**
+   * Function called wwhen the component is about to be removed from the DOM.
+   * It passes the popover as argument
+   */
+  @argument
+  @type(optional(Action))
+  willDestroyCallback = null;
+
+  /**
    * Opens the popover programatically
    */
   open() {
@@ -210,6 +218,8 @@ export default class BasePopMenuComponent extends Component {
     this._triggerElement.removeAttribute('data-popover-trigger');
 
     this._rootElement.removeEventListener('mouseup', this._handleBodyClick);
+
+    this.sendAction('willDestroyCallback', this);
   }
 
   /**

--- a/tests/integration/components/adde-dropdown-test.js
+++ b/tests/integration/components/adde-dropdown-test.js
@@ -399,6 +399,40 @@ test('The dropdown can be positioned to another element than its parent', async 
   );
 });
 
+test('The dropdown sends didInsertCallback and willDestroyCallback actions', async function(assert) {
+  assert.expect(2);
+
+  this.on('didInsert', component => {
+    assert.ok(component, 'didInsert action is sent');
+  });
+  this.on('willDestroy', component => {
+    assert.ok(component, 'willDestroy action is sent');
+  });
+
+  this.set('isVisible', true);
+
+  this.render(hbs`
+    {{#if isVisible}}
+    <button style="width: 200px; height: 20px;">
+      Target
+      {{#adde-dropdown
+        data-test-dropdown=true
+        placement="bottom-start"
+        didInsertCallback='didInsert'
+        willDestroyCallback='willDestroy'
+      }}
+        <ul class="adde-dropdown-menu">
+          <li><button data-test-menu-item1 data-close>Item 1</button></li>
+          <li><button data-test-menu-item2 data-close>Item 2</button></li>
+        </ul>
+      {{/adde-dropdown}}
+    </button>
+    {{/if}}
+  `);
+
+  this.set('isVisible', false);
+});
+
 test('The dropdown can be opened programmatically', async function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Add the teardown equivalent to the `didInsertCallback` action implemented in 48a41cd5dd1493e3861a79f2b030218170f8d986