### PR TITLE
Allow independent setting of font awesome weight

### DIFF
--- a/addon/components/adde-tooltip-icon.js
+++ b/addon/components/adde-tooltip-icon.js
@@ -25,7 +25,7 @@ import layout from '../templates/components/adde-tooltip-icon';
  * ```
  */
 @tagName('i')
-@classNames('fas', 'tooltip-icon')
+@classNames('tooltip-icon')
 export default class AddeTooltipIcon extends Component {
   layout = layout;
 
@@ -59,4 +59,20 @@ export default class AddeTooltipIcon extends Component {
   @argument
   @type('string')
   tooltipClass = '';
+
+  /**
+   * An optional weight defaults to strong with a class of "fas"
+   *
+   * Valid options include:
+   * fa
+   * fas
+   * far
+   * fal
+   * fad
+   * fab
+   */
+  @argument
+  @type('string')
+  @className
+  iconWeightClass = 'fas';
 }

--- a/tests/integration/components/adde-tooltip-icon-test.js
+++ b/tests/integration/components/adde-tooltip-icon-test.js
@@ -112,3 +112,32 @@ test('tooltip box direction can be modified', async function(assert) {
     'tooltip box reflects correct direction'
   );
 });
+
+test('tooltip can set iconWeight', async function(assert) {
+  assert.expect(2);
+
+  this.render(hbs`
+    {{#adde-tooltip-icon data-test-tooltip-icon=true iconWeight="far"}}
+      template block text
+    {{/adde-tooltip-icon}}
+  `);
+
+  let icon = new IconHelper();
+
+  assert.ok(icon.isIcon('far'), 'tooltip icon has new class');
+  assert.ok(!icon.isIcon('fas'), 'tooltip icon no longer has default class');
+});
+
+test('tooltip can set iconWeight defaults to fas', async function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    {{#adde-tooltip-icon data-test-tooltip-icon=true}}
+      template block text
+    {{/adde-tooltip-icon}}
+  `);
+
+  let icon = new IconHelper();
+
+  assert.ok(icon.isIcon('fas'), 'tooltip icon has new class');
+});


### PR DESCRIPTION
Previous to this commit the `fas` class would always be set and if
another weight was selected it was ignored.

This manifested when trying to include an information icon where with
the `fas` (font awesome strong) class the negative space is filled in to
be bolder and we were unable to use the `far` (font awesome regular)
class without this fix.