### PR TITLE
Yield the close-popover handler from adde-popover

### DIFF
--- a/addon/templates/components/adde-popover.hbs
+++ b/addon/templates/components/adde-popover.hbs
@@ -11,7 +11,7 @@
     {{#if popoverTitle}}
       <header class="adde-popover-title" data-test-popover-header>{{popoverTitle}}</header>
     {{/if}}
-    {{yield}}
+    {{yield _closePopoverHandler}}
   </div>
   <div class="popper-arrow" x-arrow></div>
 {{/animated-popper}}


### PR DESCRIPTION
Updates the `adde-popover` template to yield the same close-popover handler that is already yielded by adde-dropdown, see:

https://github.com/Addepar/addepar-pop-menu/blob/d413b6717aa1e3a0b7943714238eb8ac47b11ec7/addon/templates/components/adde-dropdown.hbs#L11-L13

Seems like the preferred method is to add `data-close` attr inside the yielded content to make the popover close, but for use cases that require programmatic control, yielding the close function is needed.

The use case I have is a component that wants to close its containing popover in response to a `dragLeave` event.