### PR TITLE
Add public "close()" method to complement "open()"

### DIFF
--- a/addon/components/-private/base-pop-menu.js
+++ b/addon/components/-private/base-pop-menu.js
@@ -121,6 +121,13 @@ export default class BasePopMenuComponent extends Component {
     return this._openPopoverHandler();
   }
 
+  /**
+   * Closes the popover programatically
+   */
+  close() {
+    return this._closePopoverHandler();
+  }
+
   // ----- Private Variables -----
 
   /**


### PR DESCRIPTION
The Popover (and Dropdown) classes already expose a public `open()` method. This adds a public `close()` method to complement it.